### PR TITLE
refactor config

### DIFF
--- a/internal/templates/test-amf-availability.go
+++ b/internal/templates/test-amf-availability.go
@@ -5,22 +5,19 @@
 package templates
 
 import (
-	log "github.com/sirupsen/logrus"
 	"my5G-RANTester/config"
 	"my5G-RANTester/internal/control_test_engine/gnb"
 	"my5G-RANTester/internal/monitoring"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func TestAvailability(interval int) {
 
 	monitor := monitoring.Monitor{}
 
-	conf, err := config.GetConfig()
-	if err != nil {
-		//return nil
-		log.Fatal("Error in get configuration")
-	}
+	conf := config.GetConfig()
 
 	ranPort := 1000
 	for y := 1; y <= interval; y++ {

--- a/internal/templates/test-amf-requests-per-second.go
+++ b/internal/templates/test-amf-requests-per-second.go
@@ -7,13 +7,12 @@ package templates
 import (
 	"strconv"
 	"sync"
-)
 
-import (
-	log "github.com/sirupsen/logrus"
 	"my5G-RANTester/config"
 	"my5G-RANTester/internal/control_test_engine/gnb"
 	"my5G-RANTester/internal/monitoring"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // rajada de mensagens por segundo enviadas
@@ -28,11 +27,7 @@ func TestRqsLoop(numRqs int, interval int) int64 {
 		RqsG: 0,
 	}
 
-	cfg, err := config.GetConfig()
-	if err != nil {
-		//return nil
-		log.Fatal("Error in get configuration")
-	}
+	cfg := config.GetConfig()
 
 	ranPort := 1000
 	for y := 1; y <= interval; y++ {

--- a/internal/templates/test-attach-gnb-with-configuration.go
+++ b/internal/templates/test-attach-gnb-with-configuration.go
@@ -5,7 +5,6 @@
 package templates
 
 import (
-	log "github.com/sirupsen/logrus"
 	"my5G-RANTester/config"
 	"my5G-RANTester/internal/control_test_engine/gnb"
 	"sync"
@@ -15,11 +14,7 @@ func TestAttachGnbWithConfiguration() {
 
 	wg := sync.WaitGroup{}
 
-	cfg, err := config.GetConfig()
-	if err != nil {
-		//return nil
-		log.Fatal("Error in get configuration")
-	}
+	cfg := config.GetConfig()
 
 	// wrong messages:
 	// cfg.GNodeB.PlmnList.Mcc = "891"

--- a/internal/templates/test-custom-scenario.go
+++ b/internal/templates/test-custom-scenario.go
@@ -5,8 +5,6 @@
 package templates
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/tetratelabs/wazero"
 	"my5G-RANTester/config"
 	"my5G-RANTester/internal/control_test_engine/gnb"
 	"my5G-RANTester/internal/control_test_engine/procedures"
@@ -15,16 +13,15 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/tetratelabs/wazero"
 )
 
 func TestWithCustomScenario(scenarioPath string) {
 	wg := sync.WaitGroup{}
 
-	cfg, err := config.GetConfig()
-	if err != nil {
-		//return nil
-		log.Fatal("Error in get configuration")
-	}
+	cfg := config.GetConfig()
 
 	wg.Add(1)
 
@@ -40,7 +37,7 @@ func TestWithCustomScenario(scenarioPath string) {
 
 	ctx, runtime := script.NewCustomScenario(scenarioPath)
 
-	_, err = runtime.NewHostModuleBuilder("env").
+	_, err := runtime.NewHostModuleBuilder("env").
 		NewFunctionBuilder().
 		WithFunc(func(ueId uint32) {
 			ueChan <- procedures.UeTesterMessage{Type: procedures.Registration}
@@ -53,12 +50,12 @@ func TestWithCustomScenario(scenarioPath string) {
 		Export("detach").
 		NewFunctionBuilder().
 		WithFunc(func(ueId uint32, pduSessionId uint8) {
-			ueChan <- procedures.UeTesterMessage{Type: procedures.NewPDUSession, Param: pduSessionId-1}
+			ueChan <- procedures.UeTesterMessage{Type: procedures.NewPDUSession, Param: pduSessionId - 1}
 		}).
 		Export("pduSessionRequest").
 		NewFunctionBuilder().
 		WithFunc(func(ueId uint32, pduSessionId uint8) {
-			ueChan <- procedures.UeTesterMessage{Type: procedures.DestroyPDUSession, Param: pduSessionId-1}
+			ueChan <- procedures.UeTesterMessage{Type: procedures.DestroyPDUSession, Param: pduSessionId - 1}
 		}).
 		Export("pduSessionRelease").
 		NewFunctionBuilder().

--- a/internal/templates/test-multi-ues-in-queue.go
+++ b/internal/templates/test-multi-ues-in-queue.go
@@ -30,10 +30,7 @@ func TestMultiUesInQueue(numUes int, tunnelEnabled bool, dedicatedGnb bool, loop
 
 	wg := sync.WaitGroup{}
 
-	cfg, err := config.GetConfig()
-	if err != nil {
-		log.Fatal("[TESTER][CONFIG] Unable to read configuration")
-	}
+	cfg := config.GetConfig()
 
 	var numGnb int
 	if dedicatedGnb {
@@ -109,5 +106,5 @@ func TestMultiUesInQueue(numUes int, tunnelEnabled bool, dedicatedGnb bool, loop
 		}
 	}
 
-	time.Sleep(time.Second*2)
+	time.Sleep(time.Second * 2)
 }

--- a/internal/utils/pcap.go
+++ b/internal/utils/pcap.go
@@ -5,12 +5,13 @@
 package pcap
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/urfave/cli/v2"
-	"github.com/vishvananda/netlink"
 	"my5G-RANTester/config"
 	"net"
 	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	"github.com/vishvananda/netlink"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
@@ -23,7 +24,7 @@ func CaptureTraffic(path cli.Path) {
 		log.Fatal(err)
 	}
 
-	config, err := config.GetConfig()
+	config := config.GetConfig()
 	ip := net.ParseIP(config.AMF.Ip)
 	route, err := netlink.RouteGet(ip)
 	if err != nil || len(route) <= 0 {


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- TO DO before submitting a Pull Request, make sure to put an `x` in all the boxes -->
- [x] I have read the **CONTRIBUTING** document.
- [x] Each of my commits messages include `Signed-off-by: Author Name <authoremail@example.com>` to accept the DCO.

Now PacketRusher will search for config file under {binary's folder}/config/config.yml by default instead of in the config folder of the project.

#### Helper: 
```
akiya@packetrusher:~/packetRusher$ ./packetrusher --help
NAME:
   packetrusher - A new cli application

USAGE:
   packetrusher [global options] command [command options] [arguments...]

COMMANDS:
   ue, ue                                      Launch a gNB and a UE with a PDU Session
                                               For more complex scenario and features, use instead packetrusher multi-ue

   gnb, gnb                                    Launch only a gNB
   multi-ue-pdu, multi-ue
                                               Load endurance stress tests.
                                               Example for testing multiple UEs: multi-ue -n 5
                                               This test case will launch N UEs. See packetrusher multi-ue --help

   custom-scenario, c
   amf-load-loop, amf-load-loop
                                               Test AMF responses in interval
                                               Example for generating 20 requests to AMF per second in interval of 20 seconds: amf-load-loop -n 20 -t 20

   Test availability of AMF, amf-availability
                                               Test availability of AMF in interval
                                               Test availability of AMF in 20 seconds: amf-availability -t 20

   help, h                                     Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --config value  Configuration file path. (Default: ./config/config.yml)
   --help, -h      show help
```

#### With config path:
```
sudo ./packetrusher multi-ue -n 1 --config ../testconf.yaml
INFO[0000] Loaded config at: ../testconf.yaml
INFO[0000] PacketRusher version 1.0.1
INFO[0000] ---------------------------------------
INFO[0000] [TESTER] Starting test function: Testing registration of multiple UEs
INFO[0000] [TESTER][UE] Number of UEs: 1
INFO[0000] [TESTER][GNB] gNodeB control interface IP/Port: 127.0.0.1/9487
INFO[0000] [TESTER][GNB] gNodeB data interface IP/Port: 127.0.0.1/2152
INFO[0000] [TESTER][AMF] AMF IP/Port: 127.0.1.5/38412
INFO[0000] ---------------------------------------
```

#### With default config:
```
sudo ./packetrusher multi-ue -n 1
INFO[0000] Loaded config at: /home/akiya/packetRusher/config/config.yml
INFO[0000] PacketRusher version 1.0.1
INFO[0000] ---------------------------------------
INFO[0000] [TESTER] Starting test function: Testing registration of multiple UEs
INFO[0000] [TESTER][UE] Number of UEs: 1
INFO[0000] [TESTER][GNB] gNodeB control interface IP/Port: 192.168.11.13/9487
INFO[0000] [TESTER][GNB] gNodeB data interface IP/Port: 192.168.11.13/2152
INFO[0000] [TESTER][AMF] AMF IP/Port: 192.168.11.30/38412
INFO[0000] ---------------------------------------
```

#### With default config from outside of project root folder:
```
sudo ./packetrusher multi-ue -n 1
FATA[0000] Could not open config at "/home/akiya/config/config.yml". open /home/akiya/config/config.yml: no such file or directory
```

