### PR TITLE
Add support for NGAP Handover

### DIFF
--- a/cmd/packetrusher.go
+++ b/cmd/packetrusher.go
@@ -89,7 +89,8 @@ func main() {
 					&cli.IntFlag{Name: "number-of-ues", Value: 1, Aliases: []string{"n"}},
 					&cli.IntFlag{Name: "timeBetweenRegistration", Value: 500, Aliases: []string{"tr"}, Usage: "The time in ms, between UE registration."},
 					&cli.IntFlag{Name: "timeBeforeDeregistration", Value: 0, Aliases: []string{"td"}, Usage: "The time in ms, before a UE deregisters once it has been registered. 0 to disable auto-deregistration."},
-					&cli.IntFlag{Name: "timeBeforeHandover", Value: 0, Aliases: []string{"th"}, Usage: "The time in ms, before triggering a UE handover. 0 to disable handover. This requires at least two gNodeB, eg: two N2/N3 IPs."},
+					&cli.IntFlag{Name: "timeBeforeNgapHandover", Value: 0, Aliases: []string{"ngh"}, Usage: "The time in ms, before triggering a UE handover using NGAP Handover. 0 to disable handover. This requires at least two gNodeB, eg: two N2/N3 IPs."},
+					&cli.IntFlag{Name: "timeBeforeXnHandover", Value: 0, Aliases: []string{"xnh"}, Usage: "The time in ms, before triggering a UE handover using Xn Handover. 0 to disable handover. This requires at least two gNodeB, eg: two N2/N3 IPs."},
 					&cli.IntFlag{Name: "numPduSessions", Value: 1, Aliases: []string{"nPdu"}, Usage: "The number of PDU Sessions to create"},
 					&cli.BoolFlag{Name: "loop", Aliases: []string{"l"}, Usage: "Enable the creation of the GTP-U tunnel interface."},
 					&cli.BoolFlag{Name: "tunnel", Aliases: []string{"t"}, Usage: "Enable the creation of the GTP-U tunnel interface."},
@@ -120,7 +121,7 @@ func main() {
 						pcap.CaptureTraffic(c.Path("pcap"))
 					}
 
-					templates.TestMultiUesInQueue(numUes, c.Bool("tunnel"), c.Bool("dedicatedGnb"), c.Bool("loop"), c.Int("timeBetweenRegistration"), c.Int("timeBeforeDeregistration"), c.Int("timeBeforeHandover"), c.Int("numPduSessions"))
+					templates.TestMultiUesInQueue(numUes, c.Bool("tunnel"), c.Bool("dedicatedGnb"), c.Bool("loop"), c.Int("timeBetweenRegistration"), c.Int("timeBeforeDeregistration"), c.Int("timeBeforeNgapHandover"), c.Int("timeBeforeXnHandover"), c.Int("numPduSessions"))
 
 					return nil
 				},

--- a/internal/common/tools/tools.go
+++ b/internal/common/tools/tools.go
@@ -103,7 +103,8 @@ type UESimulationConfig struct {
 	Cfg                      config.Config
 	ScenarioChan             chan procedures.UeTesterMessage
 	TimeBeforeDeregistration int
-	TimeBeforeHandover       int
+	TimeBeforeNgapHandover   int
+	TimeBeforeXnHandover     int
 	NumPduSessions           int
 }
 
@@ -113,7 +114,9 @@ func SimulateSingleUE(simConfig UESimulationConfig, wg *sync.WaitGroup) {
 	ueCfg.Ue.Msin = IncrementMsin(simConfig.UeId, simConfig.Cfg.Ue.Msin)
 	log.Info("[TESTER] TESTING REGISTRATION USING IMSI ", ueCfg.Ue.Msin, " UE")
 
-	gnbId := gnbIdGenerator(simConfig.UeId%numGnb, ueCfg.GNodeB.PlmnList.GnbId)
+	gnbIdGen := func(index int) string {
+		return gnbIdGenerator((simConfig.UeId+index)%numGnb, ueCfg.GNodeB.PlmnList.GnbId)
+	}
 
 	// Launch a coroutine to handle UE's individual scenario
 	go func(scenarioChan chan procedures.UeTesterMessage, ueId int) {
@@ -123,7 +126,7 @@ func SimulateSingleUE(simConfig UESimulationConfig, wg *sync.WaitGroup) {
 
 		// Create a new UE coroutine
 		// ue.NewUE returns context of the new UE
-		ueTx := ue.NewUE(ueCfg, ueId, ueRx, simConfig.Gnbs[gnbId], wg)
+		ueTx := ue.NewUE(ueCfg, ueId, ueRx, simConfig.Gnbs[gnbIdGen(0)], wg)
 
 		// We tell the UE to perform a registration
 		ueRx <- procedures.UeTesterMessage{Type: procedures.Registration}
@@ -132,11 +135,19 @@ func SimulateSingleUE(simConfig UESimulationConfig, wg *sync.WaitGroup) {
 		if simConfig.TimeBeforeDeregistration != 0 {
 			deregistrationChannel = time.After(time.Duration(simConfig.TimeBeforeDeregistration) * time.Millisecond)
 		}
-		var handoverChannel <-chan time.Time = nil
-		if simConfig.TimeBeforeHandover != 0 {
-			handoverChannel = time.After(time.Duration(simConfig.TimeBeforeHandover) * time.Millisecond)
+
+		nextHandoverId := 0
+		var ngapHandoverChannel <-chan time.Time = nil
+		if simConfig.TimeBeforeNgapHandover != 0 {
+			ngapHandoverChannel = time.After(time.Duration(simConfig.TimeBeforeNgapHandover) * time.Millisecond)
+		}
+		var xnHandoverChannel <-chan time.Time = nil
+		if simConfig.TimeBeforeXnHandover != 0 {
+			xnHandoverChannel = time.After(time.Duration(simConfig.TimeBeforeXnHandover) * time.Millisecond)
 		}
 
+		log.Error(simConfig.TimeBeforeNgapHandover)
+		log.Error(simConfig.TimeBeforeXnHandover)
 		loop := true
 		state := ueCtx.MM5G_NULL
 		for loop {
@@ -146,8 +157,12 @@ func SimulateSingleUE(simConfig UESimulationConfig, wg *sync.WaitGroup) {
 					ueRx <- procedures.UeTesterMessage{Type: procedures.Terminate}
 					ueRx = nil
 				}
-			case <-handoverChannel:
-				trigger.TriggerHandover(simConfig.Gnbs[gnbId], simConfig.Gnbs[gnbIdGenerator((ueId+1)%numGnb, ueCfg.GNodeB.PlmnList.GnbId)], int64(ueId))
+			case <-ngapHandoverChannel:
+				trigger.TriggerNgapHandover(simConfig.Gnbs[gnbIdGen(nextHandoverId)], simConfig.Gnbs[gnbIdGen(nextHandoverId+1)], int64(ueId))
+				nextHandoverId++
+			case <-xnHandoverChannel:
+				trigger.TriggerXnHandover(simConfig.Gnbs[gnbIdGen(nextHandoverId)], simConfig.Gnbs[gnbIdGen(nextHandoverId+1)], int64(ueId))
+				nextHandoverId++
 			case msg := <-scenarioChan:
 				if ueRx != nil {
 					ueRx <- msg

--- a/internal/control_test_engine/gnb/context/msg.go
+++ b/internal/control_test_engine/gnb/context/msg.go
@@ -16,4 +16,5 @@ type UEMessage struct {
 	Mcc              string
 	Mnc              string
 	UEContext        *GNBUe
+	IsHandover       bool
 }

--- a/internal/control_test_engine/gnb/context/ue.go
+++ b/internal/control_test_engine/gnb/context/ue.go
@@ -29,6 +29,7 @@ type GNBUe struct {
 	pRueId         int64 // PacketRusher unique UE ID
 	context        Context
 	lock           sync.Mutex
+	newGnb         *GNBContext
 }
 
 type Context struct {
@@ -202,6 +203,14 @@ func (ue *GNBUe) SetStateReady() {
 
 func (ue *GNBUe) SetStateDown() {
 	ue.state = Down
+}
+
+func (ue *GNBUe) SetHandoverGnodeB(gnb *GNBContext) {
+	ue.newGnb = gnb
+}
+
+func (ue *GNBUe) GetHandoverGnodeB() *GNBContext {
+	return ue.newGnb
 }
 
 func (ue *GNBUe) GetGnbRx() chan UEMessage {

--- a/internal/control_test_engine/gnb/nas/service/service.go
+++ b/internal/control_test_engine/gnb/nas/service/service.go
@@ -93,7 +93,11 @@ func processingConn(ue *context.GNBUe, gnb *context.GNBContext) {
 		if message.ConnectionClosed {
 			log.Info("[GNB] Cleaning up context on current gNb")
 			gnbUeContext.SetStateDown()
-			gnb.DeleteGnBUe(ue)
+			if gnbUeContext.GetHandoverGnodeB() == nil {
+				// We do not clean the context if it's a NGAP Handover, as AMF will request the context clean-up
+				// Otherwise, we do clean the context
+				gnb.DeleteGnBUe(ue)
+			}
 		} else if message.IsNas {
 			nas.Dispatch(ue, message.Nas, gnb)
 		} else {

--- a/internal/control_test_engine/gnb/nas/service/service.go
+++ b/internal/control_test_engine/gnb/nas/service/service.go
@@ -1,12 +1,14 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  * © Copyright 2023 Hewlett Packard Enterprise Development LP
+ * © Copyright 2023 Valentin D'Emmanuele
  */
 package service
 
 import (
 	"my5G-RANTester/internal/control_test_engine/gnb/context"
 	"my5G-RANTester/internal/control_test_engine/gnb/nas"
+	"my5G-RANTester/internal/control_test_engine/gnb/nas/message/sender"
 	"my5G-RANTester/internal/control_test_engine/gnb/ngap/trigger"
 
 	log "github.com/sirupsen/logrus"
@@ -29,17 +31,36 @@ func gnbListen(gnb *context.GNBContext) {
 		// store UE connection
 		// select AMF and get sctp association
 		// make a tun interface
-		ue := gnb.NewGnBUe(message.GNBTx, message.GNBRx, message.PrUeId)
-		if message.UEContext == nil {
-			log.Info("[GNB] Received incoming connection from new UE")
-			mcc, mnc := gnb.GetMccAndMnc()
-			message.GNBTx <- context.UEMessage{Mcc: mcc, Mnc: mnc}
-			ue.SetPduSessions(message.GNBPduSessions)
-		} else {
-			log.Info("[GNB] Received incoming handover for UE from another gNodeB")
+		ue, _ := gnb.GetGnbUeByPrUeId(message.PrUeId)
+		if ue != nil && message.IsHandover {
+			// We already have a context for this UE since it was sent to us by the AMF from a NGAP Handover
+			// Notify the AMF that the UE has succesfully been handed over to US
+			ue.SetGnbRx(message.GNBRx)
+			ue.SetGnbTx(message.GNBTx)
+
+			// We enable the new PDU Session handed over to us
+			msg := context.UEMessage{GNBPduSessions: ue.GetPduSessions(), GnbIp: gnb.GetN3GnbIp()}
+			sender.SendMessageToUe(ue, msg)
+
 			ue.SetStateReady()
-			ue.CopyFromPreviousContext(message.UEContext)
-			trigger.SendPathSwitchRequest(gnb, ue)
+
+			trigger.SendHandoverNotify(gnb, ue)
+		} else {
+			ue = gnb.NewGnBUe(message.GNBTx, message.GNBRx, message.PrUeId)
+			if message.UEContext != nil && message.IsHandover {
+				// Xn Handover
+				log.Info("[GNB] Received incoming handover for UE from another gNodeB")
+				ue.SetStateReady()
+				ue.CopyFromPreviousContext(message.UEContext)
+				trigger.SendPathSwitchRequest(gnb, ue)
+
+			} else {
+				// Usual first UE connection to a gNodeB
+				log.Info("[GNB] Received incoming connection from new UE")
+				mcc, mnc := gnb.GetMccAndMnc()
+				message.GNBTx <- context.UEMessage{Mcc: mcc, Mnc: mnc}
+				ue.SetPduSessions(message.GNBPduSessions)
+			}
 		}
 
 		if ue == nil {

--- a/internal/control_test_engine/gnb/ngap/dispatcher.go
+++ b/internal/control_test_engine/gnb/ngap/dispatcher.go
@@ -66,6 +66,11 @@ func Dispatch(amf *context.GNBAmf, gnb *context.GNBContext, message []byte) {
 			log.Info("[GNB][NGAP] Receive AMF Configuration Update")
 			handler.HandlerAmfConfigurationUpdate(amf, gnb, ngapMsg)
 
+		case ngapType.ProcedureCodeHandoverResourceAllocation:
+			// handler NGAP Handover REquest
+			log.Info("[GNB][NGAP] Receive Handover Request")
+			handler.HandlerHandoverRequest(amf, gnb, ngapMsg)
+
 		case ngapType.ProcedureCodeErrorIndication:
 			// handler Error Indicator
 			log.Error("[GNB][NGAP] Receive Error Indication")
@@ -88,6 +93,11 @@ func Dispatch(amf *context.GNBAmf, gnb *context.GNBContext, message []byte) {
 			// handler PathSwitchRequestAcknowledge
 			log.Info("[GNB][NGAP] Receive PathSwitchRequestAcknowledge")
 			handler.HandlerPathSwitchRequestAcknowledge(gnb, ngapMsg)
+
+		case ngapType.ProcedureCodeHandoverPreparation:
+			// handler NGAP AMF Handover Command
+			log.Info("[GNB][NGAP] Receive Handover Command")
+			handler.HandlerHandoverCommand(amf, gnb, ngapMsg)
 
 		default:
 			log.Info("[GNB][NGAP] Received unknown NGAP message")

--- a/internal/control_test_engine/gnb/ngap/message/ngap_control/ue_mobility_management/handover-notify.go
+++ b/internal/control_test_engine/gnb/ngap/message/ngap_control/ue_mobility_management/handover-notify.go
@@ -1,0 +1,104 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * © Copyright 2023 Valentin D'Emmanuele
+ */
+package ue_mobility_management
+
+import (
+	"my5G-RANTester/internal/control_test_engine/gnb/context"
+
+	"github.com/free5gc/ngap"
+
+	"github.com/free5gc/ngap/ngapType"
+)
+
+type HandoverNotifyBuilder struct {
+	pdu ngapType.NGAPPDU
+	ies *ngapType.ProtocolIEContainerHandoverNotifyIEs
+}
+
+func HandoverNotify(gnb *context.GNBContext, ue *context.GNBUe) ([]byte, error) {
+	return NewHandoverNotifyBuilder().
+		SetAmfUeNgapId(ue.GetAmfUeId()).SetRanUeNgapId(ue.GetRanUeId()).
+		SetUserLocation(gnb).
+		Build()
+}
+
+func NewHandoverNotifyBuilder() *HandoverNotifyBuilder {
+	pdu := ngapType.NGAPPDU{}
+
+	pdu.Present = ngapType.NGAPPDUPresentInitiatingMessage
+	pdu.InitiatingMessage = new(ngapType.InitiatingMessage)
+
+	initiatingMessage := pdu.InitiatingMessage
+	initiatingMessage.ProcedureCode.Value = ngapType.ProcedureCodeHandoverNotification
+	initiatingMessage.Criticality.Value = ngapType.CriticalityPresentReject
+
+	initiatingMessage.Value.Present = ngapType.InitiatingMessagePresentHandoverNotify
+	initiatingMessage.Value.HandoverNotify = new(ngapType.HandoverNotify)
+
+	handoverNotify := initiatingMessage.Value.HandoverNotify
+	ies := &handoverNotify.ProtocolIEs
+
+	return &HandoverNotifyBuilder{pdu, ies}
+}
+
+func (builder *HandoverNotifyBuilder) SetAmfUeNgapId(amfUeNgapID int64) *HandoverNotifyBuilder {
+	// AMF UE NGAP ID
+	ie := ngapType.HandoverNotifyIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDAMFUENGAPID
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.HandoverRequiredIEsPresentAMFUENGAPID
+	ie.Value.AMFUENGAPID = new(ngapType.AMFUENGAPID)
+
+	aMFUENGAPID := ie.Value.AMFUENGAPID
+	aMFUENGAPID.Value = amfUeNgapID
+
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func (builder *HandoverNotifyBuilder) SetRanUeNgapId(ranUeNgapID int64) *HandoverNotifyBuilder {
+	// RAN UE NGAP ID
+	ie := ngapType.HandoverNotifyIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDRANUENGAPID
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.HandoverRequiredIEsPresentRANUENGAPID
+	ie.Value.RANUENGAPID = new(ngapType.RANUENGAPID)
+
+	rANUENGAPID := ie.Value.RANUENGAPID
+	rANUENGAPID.Value = ranUeNgapID
+
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func (builder *HandoverNotifyBuilder) SetUserLocation(gnb *context.GNBContext) *HandoverNotifyBuilder {
+	// User Location Information
+	ie := ngapType.HandoverNotifyIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDUserLocationInformation
+	ie.Criticality.Value = ngapType.CriticalityPresentIgnore
+	ie.Value.Present = ngapType.HandoverNotifyIEsPresentUserLocationInformation
+	ie.Value.UserLocationInformation = new(ngapType.UserLocationInformation)
+
+	userLocationInformation := ie.Value.UserLocationInformation
+	userLocationInformation.Present = ngapType.UserLocationInformationPresentUserLocationInformationNR
+	userLocationInformation.UserLocationInformationNR = new(ngapType.UserLocationInformationNR)
+
+	userLocationInformationNR := userLocationInformation.UserLocationInformationNR
+	userLocationInformationNR.NRCGI.PLMNIdentity = gnb.GetPLMNIdentity()
+	userLocationInformationNR.NRCGI.NRCellIdentity = gnb.GetNRCellIdentity()
+
+	userLocationInformationNR.TAI.PLMNIdentity = gnb.GetPLMNIdentity()
+	userLocationInformationNR.TAI.TAC.Value = gnb.GetTacInBytes()
+
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func (builder *HandoverNotifyBuilder) Build() ([]byte, error) {
+	return ngap.Encoder(builder.pdu)
+}

--- a/internal/control_test_engine/gnb/ngap/message/ngap_control/ue_mobility_management/handover-request-acknowledge.go
+++ b/internal/control_test_engine/gnb/ngap/message/ngap_control/ue_mobility_management/handover-request-acknowledge.go
@@ -1,0 +1,174 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * © Copyright 2023 Valentin D'Emmanuele
+ */
+package ue_mobility_management
+
+import (
+	"encoding/binary"
+	"my5G-RANTester/internal/control_test_engine/gnb/context"
+
+	"github.com/free5gc/aper"
+	"github.com/free5gc/ngap"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/free5gc/ngap/ngapConvert"
+	"github.com/free5gc/ngap/ngapType"
+)
+
+type HandoverRequestAcknowledgeBuilder struct {
+	pdu ngapType.NGAPPDU
+	ies *ngapType.ProtocolIEContainerHandoverRequestAcknowledgeIEs
+}
+
+func HandoverRequestAcknowledge(gnb *context.GNBContext, ue *context.GNBUe) ([]byte, error) {
+	return NewHandoverRequestAcknowledgeBuilder().
+		SetAmfUeNgapId(ue.GetAmfUeId()).SetRanUeNgapId(ue.GetRanUeId()).
+		SetPduSessionResourceAdmittedList(gnb, ue.GetPduSessions()).
+		SetTargetToSourceContainer().
+		Build()
+}
+
+func NewHandoverRequestAcknowledgeBuilder() *HandoverRequestAcknowledgeBuilder {
+	pdu := ngapType.NGAPPDU{}
+
+	pdu.Present = ngapType.NGAPPDUPresentSuccessfulOutcome
+	pdu.SuccessfulOutcome = new(ngapType.SuccessfulOutcome)
+
+	successfulOutcome := pdu.SuccessfulOutcome
+	successfulOutcome.ProcedureCode.Value = ngapType.ProcedureCodeHandoverResourceAllocation
+	successfulOutcome.Criticality.Value = ngapType.CriticalityPresentReject
+
+	successfulOutcome.Value.Present = ngapType.SuccessfulOutcomePresentHandoverRequestAcknowledge
+	successfulOutcome.Value.HandoverRequestAcknowledge = new(ngapType.HandoverRequestAcknowledge)
+
+	handoverRequestAcknowledge := successfulOutcome.Value.HandoverRequestAcknowledge
+	ies := &handoverRequestAcknowledge.ProtocolIEs
+
+	return &HandoverRequestAcknowledgeBuilder{pdu, ies}
+}
+
+func (builder *HandoverRequestAcknowledgeBuilder) SetAmfUeNgapId(amfUeNgapID int64) *HandoverRequestAcknowledgeBuilder {
+	// AMF UE NGAP ID
+	ie := ngapType.HandoverRequestAcknowledgeIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDAMFUENGAPID
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.HandoverRequiredIEsPresentAMFUENGAPID
+	ie.Value.AMFUENGAPID = new(ngapType.AMFUENGAPID)
+
+	aMFUENGAPID := ie.Value.AMFUENGAPID
+	aMFUENGAPID.Value = amfUeNgapID
+
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func (builder *HandoverRequestAcknowledgeBuilder) SetRanUeNgapId(ranUeNgapID int64) *HandoverRequestAcknowledgeBuilder {
+	// RAN UE NGAP ID
+	ie := ngapType.HandoverRequestAcknowledgeIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDRANUENGAPID
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.HandoverRequiredIEsPresentRANUENGAPID
+	ie.Value.RANUENGAPID = new(ngapType.RANUENGAPID)
+
+	rANUENGAPID := ie.Value.RANUENGAPID
+	rANUENGAPID.Value = ranUeNgapID
+
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func (builder *HandoverRequestAcknowledgeBuilder) SetPduSessionResourceAdmittedList(gnb *context.GNBContext, pduSessions [16]*context.GnbPDUSession) *HandoverRequestAcknowledgeBuilder {
+	ie := ngapType.HandoverRequestAcknowledgeIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDPDUSessionResourceAdmittedList
+	ie.Criticality.Value = ngapType.CriticalityPresentIgnore
+	ie.Value.Present = ngapType.HandoverRequestAcknowledgeIEsPresentPDUSessionResourceAdmittedList
+	ie.Value.PDUSessionResourceAdmittedList = new(ngapType.PDUSessionResourceAdmittedList)
+
+	pDUSessionResourceAdmittedList := ie.Value.PDUSessionResourceAdmittedList
+
+	for _, pduSession := range pduSessions {
+		if pduSession == nil {
+			continue
+		}
+		//PDU SessionResource Admittedy Item
+		pDUSessionResourceAdmittedItem := ngapType.PDUSessionResourceAdmittedItem{}
+		pDUSessionResourceAdmittedItem.PDUSessionID.Value = pduSession.GetPduSessionId()
+		pDUSessionResourceAdmittedItem.HandoverRequestAcknowledgeTransfer = GetHandoverRequestAcknowledgeTransfer(gnb, pduSession)
+
+		pDUSessionResourceAdmittedList.List = append(pDUSessionResourceAdmittedList.List, pDUSessionResourceAdmittedItem)
+	}
+
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func (builder *HandoverRequestAcknowledgeBuilder) SetTargetToSourceContainer() *HandoverRequestAcknowledgeBuilder {
+	// Target To Source TransparentContainer
+	ie := ngapType.HandoverRequestAcknowledgeIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDTargetToSourceTransparentContainer
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.HandoverRequestAcknowledgeIEsPresentTargetToSourceTransparentContainer
+	ie.Value.TargetToSourceTransparentContainer = new(ngapType.TargetToSourceTransparentContainer)
+
+	targetToSourceTransparentContainer := ie.Value.TargetToSourceTransparentContainer
+	targetToSourceTransparentContainer.Value = GetTargetToSourceTransparentTransfer()
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func (builder *HandoverRequestAcknowledgeBuilder) Build() ([]byte, error) {
+	return ngap.Encoder(builder.pdu)
+}
+
+func GetHandoverRequestAcknowledgeTransfer(gnb *context.GNBContext, pduSession *context.GnbPDUSession) []byte {
+	data := buildHandoverRequestAcknowledgeTransfer(gnb, pduSession)
+	encodeData, err := aper.MarshalWithParams(data, "valueExt")
+	if err != nil {
+		log.Fatalf("aper MarshalWithParams error in GetHandoverRequestAcknowledgeTransfer: %+v", err)
+	}
+	return encodeData
+}
+
+func buildHandoverRequestAcknowledgeTransfer(gnb *context.GNBContext, pduSession *context.GnbPDUSession) (data ngapType.HandoverRequestAcknowledgeTransfer) {
+
+	// DL NG-U UP TNL information
+	dlTransportLayerInformation := &data.DLNGUUPTNLInformation
+	dlTransportLayerInformation.Present = ngapType.UPTransportLayerInformationPresentGTPTunnel
+	dlTransportLayerInformation.GTPTunnel = new(ngapType.GTPTunnel)
+	downlinkTeid := make([]byte, 4)
+	binary.BigEndian.PutUint32(downlinkTeid, pduSession.GetTeidDownlink())
+	dlTransportLayerInformation.GTPTunnel.GTPTEID.Value = downlinkTeid
+	dlTransportLayerInformation.GTPTunnel.TransportLayerAddress = ngapConvert.IPAddressToNgap(gnb.GetN3GnbIp(), "")
+
+	// Qos Flow Setup Response List
+	qosFlowSetupResponseItem := ngapType.QosFlowItemWithDataForwarding{
+		QosFlowIdentifier: ngapType.QosFlowIdentifier{
+			Value: 1,
+		},
+	}
+
+	data.QosFlowSetupResponseList.List = append(data.QosFlowSetupResponseList.List, qosFlowSetupResponseItem)
+
+	return data
+}
+
+func GetTargetToSourceTransparentTransfer() []byte {
+	data := buildTargetToSourceTransparentTransfer()
+	encodeData, err := aper.MarshalWithParams(data, "valueExt")
+	if err != nil {
+		log.Fatalf("aper MarshalWithParams error in GetTargetToSourceTransparentTransfer: %+v", err)
+	}
+	return encodeData
+}
+
+func buildTargetToSourceTransparentTransfer() (data ngapType.TargetNGRANNodeToSourceNGRANNodeTransparentContainer) {
+	// RRC Container
+	data.RRCContainer.Value = aper.OctetString("\x00\x00\x11")
+
+	return data
+}

--- a/internal/control_test_engine/gnb/ngap/message/ngap_control/ue_mobility_management/handover-required.go
+++ b/internal/control_test_engine/gnb/ngap/message/ngap_control/ue_mobility_management/handover-required.go
@@ -1,0 +1,257 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * © Copyright 2023 Valentin D'Emmanuele
+ */
+package ue_mobility_management
+
+import (
+	"my5G-RANTester/internal/control_test_engine/gnb/context"
+
+	"github.com/free5gc/ngap"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/free5gc/aper"
+
+	"github.com/free5gc/ngap/ngapType"
+)
+
+type HandoverRequiredBuilder struct {
+	pdu ngapType.NGAPPDU
+	ies *ngapType.ProtocolIEContainerHandoverRequiredIEs
+}
+
+func HandoverRequired(sourceGnb *context.GNBContext, targetGnb *context.GNBContext, ue *context.GNBUe) ([]byte, error) {
+	return NewHandoverRequiredBuilder().
+		SetAmfUeNgapId(ue.GetAmfUeId()).SetRanUeNgapId(ue.GetRanUeId()).
+		SetHandoverType(ngapType.HandoverTypePresentIntra5gs).
+		SetCause(ngapType.CauseRadioNetworkPresentHandoverDesirableForRadioReason).
+		SetPduSessionResourceList(ue.GetPduSessions()).
+		SetTargetGnodeB(targetGnb).
+		SetSourceToTargetContainer(sourceGnb, targetGnb, ue.GetPduSessions(), ue.GetPrUeId()).
+		Build()
+}
+
+func NewHandoverRequiredBuilder() *HandoverRequiredBuilder {
+	pdu := ngapType.NGAPPDU{}
+
+	pdu.Present = ngapType.NGAPPDUPresentInitiatingMessage
+	pdu.InitiatingMessage = new(ngapType.InitiatingMessage)
+
+	initiatingMessage := pdu.InitiatingMessage
+	initiatingMessage.ProcedureCode.Value = ngapType.ProcedureCodeHandoverPreparation
+	initiatingMessage.Criticality.Value = ngapType.CriticalityPresentReject
+
+	initiatingMessage.Value.Present = ngapType.InitiatingMessagePresentHandoverRequired
+	initiatingMessage.Value.HandoverRequired = new(ngapType.HandoverRequired)
+
+	handoverRequired := initiatingMessage.Value.HandoverRequired
+	ies := &handoverRequired.ProtocolIEs
+
+	return &HandoverRequiredBuilder{pdu, ies}
+}
+
+func (builder *HandoverRequiredBuilder) SetAmfUeNgapId(amfUeNgapID int64) *HandoverRequiredBuilder {
+	// AMF UE NGAP ID
+	ie := ngapType.HandoverRequiredIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDAMFUENGAPID
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.HandoverRequiredIEsPresentAMFUENGAPID
+	ie.Value.AMFUENGAPID = new(ngapType.AMFUENGAPID)
+
+	aMFUENGAPID := ie.Value.AMFUENGAPID
+	aMFUENGAPID.Value = amfUeNgapID
+
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func (builder *HandoverRequiredBuilder) SetRanUeNgapId(ranUeNgapID int64) *HandoverRequiredBuilder {
+	// RAN UE NGAP ID
+	ie := ngapType.HandoverRequiredIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDRANUENGAPID
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.HandoverRequiredIEsPresentRANUENGAPID
+	ie.Value.RANUENGAPID = new(ngapType.RANUENGAPID)
+
+	rANUENGAPID := ie.Value.RANUENGAPID
+	rANUENGAPID.Value = ranUeNgapID
+
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func (builder *HandoverRequiredBuilder) SetHandoverType(handoverTypeValue aper.Enumerated) *HandoverRequiredBuilder {
+	// Handover Type
+	ie := ngapType.HandoverRequiredIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDHandoverType
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.HandoverRequiredIEsPresentHandoverType
+	ie.Value.HandoverType = new(ngapType.HandoverType)
+
+	handoverType := ie.Value.HandoverType
+	handoverType.Value = handoverTypeValue
+
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func (builder *HandoverRequiredBuilder) SetCause(causeValue aper.Enumerated) *HandoverRequiredBuilder {
+	// Cause
+	ie := ngapType.HandoverRequiredIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDCause
+	ie.Criticality.Value = ngapType.CriticalityPresentIgnore
+	ie.Value.Present = ngapType.HandoverRequiredIEsPresentCause
+	ie.Value.Cause = new(ngapType.Cause)
+
+	cause := ie.Value.Cause
+	cause.Present = ngapType.CausePresentRadioNetwork
+	cause.RadioNetwork = new(ngapType.CauseRadioNetwork)
+	cause.RadioNetwork.Value = causeValue
+
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func (builder *HandoverRequiredBuilder) SetTargetGnodeB(targetGnb *context.GNBContext) *HandoverRequiredBuilder {
+	// Target ID
+	ie := ngapType.HandoverRequiredIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDTargetID
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.HandoverRequiredIEsPresentTargetID
+	ie.Value.TargetID = new(ngapType.TargetID)
+
+	targetID := ie.Value.TargetID
+	targetID.Present = ngapType.TargetIDPresentTargetRANNodeID
+	targetID.TargetRANNodeID = new(ngapType.TargetRANNodeID)
+
+	targetRANNodeID := targetID.TargetRANNodeID
+	targetRANNodeID.GlobalRANNodeID.Present = ngapType.GlobalRANNodeIDPresentGlobalGNBID
+	targetRANNodeID.GlobalRANNodeID.GlobalGNBID = new(ngapType.GlobalGNBID)
+
+	globalRANNodeID := targetRANNodeID.GlobalRANNodeID
+	globalRANNodeID.GlobalGNBID.PLMNIdentity = targetGnb.GetPLMNIdentity()
+	globalRANNodeID.GlobalGNBID.GNBID.Present = ngapType.GNBIDPresentGNBID
+
+	globalRANNodeID.GlobalGNBID.GNBID.GNBID = new(aper.BitString)
+
+	gNBID := globalRANNodeID.GlobalGNBID.GNBID.GNBID
+
+	*gNBID = aper.BitString{
+		Bytes:     targetGnb.GetGnbIdInBytes(),
+		BitLength: uint64(len(targetGnb.GetGnbIdInBytes()) * 8),
+	}
+	globalRANNodeID.GlobalGNBID.PLMNIdentity = targetGnb.GetPLMNIdentity()
+
+	targetRANNodeID.SelectedTAI.PLMNIdentity = targetGnb.GetPLMNIdentity()
+	targetRANNodeID.SelectedTAI.TAC.Value = targetGnb.GetTacInBytes()
+
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func (builder *HandoverRequiredBuilder) SetPduSessionResourceList(pduSessions [16]*context.GnbPDUSession) *HandoverRequiredBuilder {
+	// PDU Session Resource List
+	ie := ngapType.HandoverRequiredIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDPDUSessionResourceListHORqd
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.HandoverRequiredIEsPresentPDUSessionResourceListHORqd
+	ie.Value.PDUSessionResourceListHORqd = new(ngapType.PDUSessionResourceListHORqd)
+
+	pDUSessionResourceListHORqd := ie.Value.PDUSessionResourceListHORqd
+
+	for _, pduSession := range pduSessions {
+		if pduSession == nil {
+			continue
+		}
+		res, _ := aper.MarshalWithParams(ngapType.HandoverRequiredTransfer{}, "valueExt")
+
+		pDUSessionResourceItem := ngapType.PDUSessionResourceItemHORqd{
+			PDUSessionID: ngapType.PDUSessionID{
+				Value: pduSession.GetPduSessionId(),
+			},
+			HandoverRequiredTransfer: res,
+		}
+
+		pDUSessionResourceListHORqd.List = append(pDUSessionResourceListHORqd.List, pDUSessionResourceItem)
+	}
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func (builder *HandoverRequiredBuilder) SetSourceToTargetContainer(sourceGnb *context.GNBContext, targetGnb *context.GNBContext, pduSessions [16]*context.GnbPDUSession, prUeId int64) *HandoverRequiredBuilder {
+	// Source to Target Transparent Container
+	ie := ngapType.HandoverRequiredIEs{}
+	ie.Id.Value = ngapType.ProtocolIEIDSourceToTargetTransparentContainer
+	ie.Criticality.Value = ngapType.CriticalityPresentReject
+	ie.Value.Present = ngapType.HandoverRequiredIEsPresentSourceToTargetTransparentContainer
+	ie.Value.SourceToTargetTransparentContainer = new(ngapType.SourceToTargetTransparentContainer)
+
+	ie.Value.SourceToTargetTransparentContainer.Value = GetSourceToTargetTransparentTransfer(sourceGnb, targetGnb, pduSessions, prUeId)
+
+	builder.ies.List = append(builder.ies.List, ie)
+
+	return builder
+}
+
+func GetSourceToTargetTransparentTransfer(sourceGnb *context.GNBContext, targetGnb *context.GNBContext, pduSessions [16]*context.GnbPDUSession, prUeId int64) []byte {
+	data := buildSourceToTargetTransparentTransfer(sourceGnb, targetGnb, pduSessions, prUeId)
+	encodeData, err := aper.MarshalWithParams(data, "valueExt")
+	if err != nil {
+		log.Fatalf("aper MarshalWithParams error in GetSourceToTargetTransparentTransfer: %+v", err)
+	}
+	return encodeData
+}
+
+func buildSourceToTargetTransparentTransfer(sourceGnb *context.GNBContext, targetGnb *context.GNBContext, pduSessions [16]*context.GnbPDUSession, prUeId int64) (data ngapType.SourceNGRANNodeToTargetNGRANNodeTransparentContainer) {
+
+	// RRC Container
+	data.RRCContainer.Value = aper.OctetString("\x00\x00\x11")
+
+	data.IndexToRFSP = &ngapType.IndexToRFSP{Value: prUeId}
+
+	// PDU Session Resource Information List
+	data.PDUSessionResourceInformationList = new(ngapType.PDUSessionResourceInformationList)
+	for _, pduSession := range pduSessions {
+		if pduSession == nil {
+			continue
+		}
+		infoItem := ngapType.PDUSessionResourceInformationItem{}
+		infoItem.PDUSessionID.Value = pduSession.GetPduSessionId()
+		qosItem := ngapType.QosFlowInformationItem{}
+		qosItem.QosFlowIdentifier.Value = 1
+		infoItem.QosFlowInformationList.List = append(infoItem.QosFlowInformationList.List, qosItem)
+		data.PDUSessionResourceInformationList.List = append(data.PDUSessionResourceInformationList.List, infoItem)
+	}
+
+	// Target Cell ID
+	data.TargetCellID.Present = ngapType.TargetIDPresentTargetRANNodeID
+	data.TargetCellID.NRCGI = new(ngapType.NRCGI)
+	data.TargetCellID.NRCGI.PLMNIdentity = targetGnb.GetPLMNIdentity()
+	data.TargetCellID.NRCGI.NRCellIdentity = targetGnb.GetNRCellIdentity()
+
+	// UE History Information
+	lastVisitedCellItem := ngapType.LastVisitedCellItem{}
+	lastVisitedCellInfo := &lastVisitedCellItem.LastVisitedCellInformation
+	lastVisitedCellInfo.Present = ngapType.LastVisitedCellInformationPresentNGRANCell
+	lastVisitedCellInfo.NGRANCell = new(ngapType.LastVisitedNGRANCellInformation)
+	ngRanCell := lastVisitedCellInfo.NGRANCell
+	ngRanCell.GlobalCellID.Present = ngapType.NGRANCGIPresentNRCGI
+	ngRanCell.GlobalCellID.NRCGI = new(ngapType.NRCGI)
+	ngRanCell.GlobalCellID.NRCGI.PLMNIdentity = sourceGnb.GetPLMNIdentity()
+	ngRanCell.GlobalCellID.NRCGI.NRCellIdentity = sourceGnb.GetNRCellIdentity()
+	ngRanCell.CellType.CellSize.Value = ngapType.CellSizePresentVerysmall
+	ngRanCell.TimeUEStayedInCell.Value = 10
+
+	data.UEHistoryInformation.List = append(data.UEHistoryInformation.List, lastVisitedCellItem)
+	return data
+}
+
+func (builder *HandoverRequiredBuilder) Build() ([]byte, error) {
+	return ngap.Encoder(builder.pdu)
+}

--- a/internal/control_test_engine/gnb/ngap/message/ngap_control/ue_mobility_management/path-switch-request.go
+++ b/internal/control_test_engine/gnb/ngap/message/ngap_control/ue_mobility_management/path-switch-request.go
@@ -27,7 +27,7 @@ func PathSwitchRequest(gnb *context.GNBContext, ue *context.GNBUe) ([]byte, erro
 		SetSourceAmfUeNgapId(ue.GetAmfUeId()).
 		SetRanUeNgapId(ue.GetRanUeId()).
 		PathSwitchRequestTransfer(gnb.GetN3GnbIp(), ue.GetPduSessions()).
-		SetUserLocation(gnb.GetMccAndMncInOctets(), gnb.GetTacInBytes()).
+		SetUserLocation(gnb).
 		SetUserSecurityCapabilities(ue.GetUESecurityCapabilities()).
 		Build()
 }
@@ -82,7 +82,7 @@ func (builder *PathSwitchRequestBuilder) SetRanUeNgapId(ranUeNgapID int64) *Path
 	return builder
 }
 
-func (builder *PathSwitchRequestBuilder) SetUserLocation(plmn []byte, tac []byte) *PathSwitchRequestBuilder {
+func (builder *PathSwitchRequestBuilder) SetUserLocation(gnb *context.GNBContext) *PathSwitchRequestBuilder {
 	// User Location Information
 	ie := ngapType.PathSwitchRequestIEs{}
 	ie.Id.Value = ngapType.ProtocolIEIDUserLocationInformation
@@ -95,14 +95,11 @@ func (builder *PathSwitchRequestBuilder) SetUserLocation(plmn []byte, tac []byte
 	userLocationInformation.UserLocationInformationNR = new(ngapType.UserLocationInformationNR)
 
 	userLocationInformationNR := userLocationInformation.UserLocationInformationNR
-	userLocationInformationNR.NRCGI.PLMNIdentity.Value = plmn
-	userLocationInformationNR.NRCGI.NRCellIdentity.Value = aper.BitString{
-		Bytes:     []byte{0x00, 0x00, 0x00, 0x00, 0x10},
-		BitLength: 36,
-	}
+	userLocationInformationNR.NRCGI.PLMNIdentity = gnb.GetPLMNIdentity()
+	userLocationInformationNR.NRCGI.NRCellIdentity = gnb.GetNRCellIdentity()
 
-	userLocationInformationNR.TAI.PLMNIdentity.Value = plmn
-	userLocationInformationNR.TAI.TAC.Value = tac
+	userLocationInformationNR.TAI.PLMNIdentity = gnb.GetPLMNIdentity()
+	userLocationInformationNR.TAI.TAC.Value = gnb.GetTacInBytes()
 
 	builder.ies.List = append(builder.ies.List, ie)
 

--- a/internal/control_test_engine/ue/gtp/service/service.go
+++ b/internal/control_test_engine/ue/gtp/service/service.go
@@ -52,6 +52,10 @@ func SetupGtpInterface(ue *context.UEContext, msg gnbContext.UEMessage) {
 
 	_ = gtpLink.CmdDel(nameInf)
 
+	if pduSession.GetStopSignal() != nil {
+		close(pduSession.GetStopSignal())
+	}
+
 	go func() {
 		// This function should not return as long as the GTP-U UDP socket is open
 		if err := gtpLink.CmdAdd(nameInf, 1, ueGnbIp.String(), stopSignal); err != nil {

--- a/internal/templates/test-attach-ue-with-configuration.go
+++ b/internal/templates/test-attach-ue-with-configuration.go
@@ -5,5 +5,5 @@
 package templates
 
 func TestAttachUeWithConfiguration(tunnelEnabled bool) {
-	TestMultiUesInQueue(1, tunnelEnabled, true, false, 500, 0, 0, 1)
+	TestMultiUesInQueue(1, tunnelEnabled, true, false, 500, 0, 0, 0, 1)
 }

--- a/internal/templates/test-multi-ues-in-queue.go
+++ b/internal/templates/test-multi-ues-in-queue.go
@@ -16,7 +16,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func TestMultiUesInQueue(numUes int, tunnelEnabled bool, dedicatedGnb bool, loop bool, timeBetweenRegistration int, timeBeforeDeregistration int, timeBeforeHandover int, numPduSessions int) {
+func TestMultiUesInQueue(numUes int, tunnelEnabled bool, dedicatedGnb bool, loop bool, timeBetweenRegistration int, timeBeforeDeregistration int, timeBeforeNgapHandover int, timeBeforeXnHandover int, numPduSessions int) {
 	if tunnelEnabled && !dedicatedGnb {
 		log.Fatal("You cannot use the --tunnel option, without using the --dedicatedGnb option")
 	}
@@ -38,7 +38,7 @@ func TestMultiUesInQueue(numUes int, tunnelEnabled bool, dedicatedGnb bool, loop
 	} else {
 		numGnb = 1
 	}
-	if numGnb <= 1 && timeBeforeHandover != 0 {
+	if numGnb <= 1 && (timeBeforeXnHandover != 0 || timeBeforeNgapHandover != 0) {
 		log.Warn("[TESTER] We are increasing the number of gNodeB to two for handover test cases. Make you sure you fill the requirements for having two gNodeBs.")
 		numGnb++
 	}
@@ -59,7 +59,8 @@ func TestMultiUesInQueue(numUes int, tunnelEnabled bool, dedicatedGnb bool, loop
 		Gnbs:                     gnbs,
 		Cfg:                      cfg,
 		TimeBeforeDeregistration: timeBeforeDeregistration,
-		TimeBeforeHandover:       timeBeforeHandover,
+		TimeBeforeNgapHandover:   timeBeforeNgapHandover,
+		TimeBeforeXnHandover:     timeBeforeXnHandover,
 		NumPduSessions:           numPduSessions,
 	}
 

--- a/test/pr_test.go
+++ b/test/pr_test.go
@@ -103,7 +103,8 @@ func TestRegistrationToCtxReleaseWithPDUSession(t *testing.T) {
 		Gnbs:                     gnbs,
 		Cfg:                      conf,
 		TimeBeforeDeregistration: 400,
-		TimeBeforeHandover:       0,
+		TimeBeforeNgapHandover:   0,
+		TimeBeforeXnHandover:     0,
 		NumPduSessions:           1,
 	}
 
@@ -198,7 +199,8 @@ func TestUERegistrationLoop(t *testing.T) {
 		Gnbs:                     gnbs,
 		Cfg:                      conf,
 		TimeBeforeDeregistration: 3000,
-		TimeBeforeHandover:       0,
+		TimeBeforeNgapHandover:   0,
+		TimeBeforeXnHandover:     0,
 		NumPduSessions:           1,
 	}
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)
- Huge new feature: Support for NGAP Handover
- Tested alongside [Open5GS](https://github.com/open5gs/open5gs), to be tested with Proprietary 5GC
- Modified test scenario so UE can be moved from gNodeB 1 to gNodeB 2 using Xn Handover and then back from gNodeB 2 to gNodeB 1 using NGAP Handover.
   - Added timeBeforeNgapHandover and timeBeforeXnHandover timer in multi-ue scenario
- PDU Session traffic continuity is assured between both NGAP and Xn handover, and ping will continue to go through during both successive Xn and NGAP Handover
![Screenshot from 2023-12-28 21-49-09](https://github.com/HewlettPackard/PacketRusher/assets/8758184/a992b597-ce10-42f2-a635-7b338b8dcb21)
- PCAP: [PacketRusher-Successive NGAP Handover and then Xn Handover.zip](https://github.com/HewlettPackard/PacketRusher/files/13789410/PacketRusher-Successive.NGAP.Handover.and.then.Xn.Handover.zip)

- Can be tested with the following CLI: `sudo ./packetrusher multi-ue -n 1 -xnh 8000 -ngh 4000 --tunnel --dedicatedGnb` provided at least two IPs are available on N2/N3 (to launch two gNodeB)

<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- TO DO before submitting a Pull Request, make sure to put an `x` in all the boxes -->
- [X] I have read the **CONTRIBUTING** document.
- [X] Each of my commits messages include `Signed-off-by: Author Name <authoremail@example.com>` to accept the DCO.
