### PR TITLE
fix: use SecurityHeaderTypeIntegrityProtectedAndCiphered as Security …

### DIFF
--- a/internal/control_test_engine/ue/nas/message/nas_control/mm_5gs/deregistration-request.go
+++ b/internal/control_test_engine/ue/nas/message/nas_control/mm_5gs/deregistration-request.go
@@ -17,9 +17,9 @@ import (
 func DeregistrationRequest(ue *context.UEContext) ([]byte, error) {
 
 	pdu := getDeregistrationRequest(ue)
-	pdu, err := nas_control.EncodeNasPduWithSecurity(ue, pdu, nas.SecurityHeaderTypeIntegrityProtectedAndCipheredWithNew5gNasSecurityContext, true, false)
+	pdu, err := nas_control.EncodeNasPduWithSecurity(ue, pdu, nas.SecurityHeaderTypeIntegrityProtectedAndCiphered, true, false)
 	if err != nil {
-		return nil, fmt.Errorf("Error encoding %s IMSI UE  NAS Security Mode Complete message", ue.UeSecurity.Supi)
+		return nil, fmt.Errorf("error encoding %s IMSI UE  NAS Security Mode Complete message", ue.UeSecurity.Supi)
 	}
 	return pdu, nil
 }


### PR DESCRIPTION
…Header Type when send Deregistration Request (UE-originated)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- TO DO before submitting a Pull Request, make sure to put an `x` in all the boxes -->
- [x] I have read the **CONTRIBUTING** document.
- [x] Each of my commits messages include `Signed-off-by: Author Name <authoremail@example.com>` to accept the DCO.
