### PR TITLE
Fix #106 PacketRusher crashes during UE processing if you use a gNodeB id with a hex digit

### DIFF
--- a/internal/common/tools/tools.go
+++ b/internal/common/tools/tools.go
@@ -83,7 +83,7 @@ func gnbIdGenerator(i int, gnbId string) string {
 	}
 	base := int(gnbId_int) + i
 
-	gnbId = fmt.Sprintf("%06x", base)
+	gnbId = fmt.Sprintf("%06X", base)
 	return gnbId
 }
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
Fix #106 

<!--- Put an `x` in all the boxes that apply: -->
- [X] All new and existing tests passed.

<!--- TO DO before submitting a Pull Request, make sure to put an `x` in all the boxes -->
- [X] I have read the **CONTRIBUTING** document.
- [X] Each of my commits messages include `Signed-off-by: Author Name <authoremail@example.com>` to accept the DCO.
