### PR TITLE
Fix deadlocks when using CTRL-C or multiple procedures at the same time

### DIFF
--- a/internal/common/routine/routine.go
+++ b/internal/common/routine/routine.go
@@ -1,0 +1,50 @@
+package routine
+
+import (
+	"sync"
+)
+
+type Routine[T any] struct {
+	routineRunning bool
+	ch             chan T
+	mutex          sync.Mutex
+}
+
+func NewRoutine[T any]() Routine[T] {
+	return Routine[T]{
+		routineRunning: true,
+		ch:             make(chan T),
+	}
+}
+
+func (r *Routine[T]) DoIfRunning(f func(chan<- T)) {
+	r.mutex.Lock()
+	if r.routineRunning {
+		f(r.ch)
+	}
+	r.mutex.Unlock()
+}
+
+func (r *Routine[T]) SendIfRunning(t T) {
+	r.mutex.Lock()
+	if r.routineRunning {
+		r.ch <- t
+	}
+	r.mutex.Unlock()
+}
+
+func (r *Routine[T]) Read() <-chan T {
+	return r.ch
+}
+
+func (r *Routine[T]) StopRunning() {
+	r.mutex.Lock()
+
+	r.routineRunning = false
+	select {
+	case <-r.ch:
+	default:
+	}
+
+	r.mutex.Unlock()
+}

--- a/internal/control_test_engine/gnb/gnb.go
+++ b/internal/control_test_engine/gnb/gnb.go
@@ -48,7 +48,7 @@ func InitGnb(conf config.Config, wg *sync.WaitGroup) *context.GNBContext {
 			log.Fatal("Error in", err)
 		} else {
 			log.Info("[GNB] SCTP/NGAP service is running")
-			// wg.Add(1)
+			wg.Add(1)
 		}
 
 		trigger.SendNgSetupRequest(gnb, amf)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
WIP: Some deadlocks still happen :D
UE stalls on  the `ue.scenarioChan <- scenario.ScenarioMessage{StateChange: ue.StateMM}` in SetStateMM_DEREGISTERED()  when deregistering so UE stalls in the trigger.SendDeregistration() and never truly terminates.
Issue seems to be that the scenario routine does not seem to read on the channels (so for instance, deregistration will never happen since it'll never be caught by scenario routine).
To be investigated!

<!--- Put an `x` in all the boxes that apply: -->
- [X] All new and existing tests passed.

<!--- TO DO before submitting a Pull Request, make sure to put an `x` in all the boxes -->
- [X] I have read the **CONTRIBUTING** document.
- [X] Each of my commits messages include `Signed-off-by: Author Name <authoremail@example.com>` to accept the DCO.
