### PR TITLE
Fix packet-rusher crashing when running multi-ue cmd with loop and certain time parameters

### DIFF
--- a/cmd/packetrusher.go
+++ b/cmd/packetrusher.go
@@ -98,6 +98,7 @@ func main() {
 					&cli.IntFlag{Name: "numPduSessions", Value: 1, Aliases: []string{"nPdu"}, Usage: "The number of PDU Sessions to create"},
 					&cli.BoolFlag{Name: "loop", Aliases: []string{"l"}, Usage: "Register UEs in a loop."},
 					&cli.IntFlag{Name: "loopCount", Value: 0, Aliases: []string{"lc"}, Usage: "The number of times the loop is executed. 0 to loop infinitely."},
+					&cli.IntFlag{Name: "timeBeforeReregistration", Value: 200, Aliases: []string{"tbrr"}, Usage: "The time in ms before the UE registers again after deregistration if UE is looping."},
 					&cli.BoolFlag{Name: "tunnel", Aliases: []string{"t"}, Usage: "Enable the creation of the GTP-U tunnel interface."},
 					&cli.BoolFlag{Name: "tunnel-vrf", Value: true, Usage: "Enable/disable VRP usage of the GTP-U tunnel interface."},
 					&cli.BoolFlag{Name: "dedicatedGnb", Aliases: []string{"d"}, Usage: "Enable the creation of a dedicated gNB per UE. Require one IP on N2/N3 per gNB."},
@@ -137,7 +138,7 @@ func main() {
 							tunnelMode = config.TunnelTun
 						}
 					}
-					templates.TestMultiUesInQueue(numUes, tunnelMode, c.Bool("dedicatedGnb"), c.Bool("loop"), c.Int("loopCount"), c.Int("timeBetweenRegistration"), c.Int("timeBeforeDeregistration"), c.Int("timeBeforeNgapHandover"), c.Int("timeBeforeXnHandover"), c.Int("timeBeforeIdle"), c.Int("timeBeforeReconnecting"), c.Int("numPduSessions"))
+					templates.TestMultiUesInQueue(numUes, tunnelMode, c.Bool("dedicatedGnb"), c.Bool("loop"), c.Int("loopCount"), c.Int("timeBeforeReregistration"), c.Int("timeBetweenRegistration"), c.Int("timeBeforeDeregistration"), c.Int("timeBeforeNgapHandover"), c.Int("timeBeforeXnHandover"), c.Int("timeBeforeIdle"), c.Int("timeBeforeReconnecting"), c.Int("numPduSessions"))
 
 					return nil
 				},

--- a/cmd/packetrusher.go
+++ b/cmd/packetrusher.go
@@ -97,6 +97,7 @@ func main() {
 					&cli.IntFlag{Name: "timeBeforeReconnecting", Value: 1000, Aliases: []string{"tbr"}, Usage: "The time in ms, before reconnecting to gNodeB after switching to Idle state. Default is 1000 ms. Only work in conjunction with timeBeforeIdle."},
 					&cli.IntFlag{Name: "numPduSessions", Value: 1, Aliases: []string{"nPdu"}, Usage: "The number of PDU Sessions to create"},
 					&cli.BoolFlag{Name: "loop", Aliases: []string{"l"}, Usage: "Register UEs in a loop."},
+					&cli.IntFlag{Name: "loopCount", Value: 0, Aliases: []string{"lc"}, Usage: "The number of times the loop is executed. 0 to loop infinitely."},
 					&cli.BoolFlag{Name: "tunnel", Aliases: []string{"t"}, Usage: "Enable the creation of the GTP-U tunnel interface."},
 					&cli.BoolFlag{Name: "tunnel-vrf", Value: true, Usage: "Enable/disable VRP usage of the GTP-U tunnel interface."},
 					&cli.BoolFlag{Name: "dedicatedGnb", Aliases: []string{"d"}, Usage: "Enable the creation of a dedicated gNB per UE. Require one IP on N2/N3 per gNB."},
@@ -136,7 +137,7 @@ func main() {
 							tunnelMode = config.TunnelTun
 						}
 					}
-					templates.TestMultiUesInQueue(numUes, tunnelMode, c.Bool("dedicatedGnb"), c.Bool("loop"), c.Int("timeBetweenRegistration"), c.Int("timeBeforeDeregistration"), c.Int("timeBeforeNgapHandover"), c.Int("timeBeforeXnHandover"), c.Int("timeBeforeIdle"), c.Int("timeBeforeReconnecting"), c.Int("numPduSessions"))
+					templates.TestMultiUesInQueue(numUes, tunnelMode, c.Bool("dedicatedGnb"), c.Bool("loop"), c.Int("loopCount"), c.Int("timeBetweenRegistration"), c.Int("timeBeforeDeregistration"), c.Int("timeBeforeNgapHandover"), c.Int("timeBeforeXnHandover"), c.Int("timeBeforeIdle"), c.Int("timeBeforeReconnecting"), c.Int("numPduSessions"))
 
 					return nil
 				},

--- a/internal/common/tools/tools.go
+++ b/internal/common/tools/tools.go
@@ -109,6 +109,7 @@ type UESimulationConfig struct {
 	NumPduSessions           int
 	RegistrationLoop         bool
 	LoopCount                int
+	TimeBeforeReregistration int
 }
 
 func SimulateSingleUE(simConfig UESimulationConfig, wg *sync.WaitGroup) {
@@ -211,10 +212,10 @@ func SimulateSingleUE(simConfig UESimulationConfig, wg *sync.WaitGroup) {
 			}
 			if !simConfig.RegistrationLoop {
 				break
-			} else if simConfig.LoopCount != 0 {
-				if i == simConfig.LoopCount {
-					break
-				}
+			} else if simConfig.LoopCount != 0 && i == simConfig.LoopCount {
+				break
+			} else {
+				time.Sleep(time.Duration(simConfig.TimeBeforeReregistration) * time.Millisecond)
 			}
 		}
 	}(simConfig.ScenarioChan, simConfig.UeId)

--- a/internal/templates/test-attach-ue-with-configuration.go
+++ b/internal/templates/test-attach-ue-with-configuration.go
@@ -11,5 +11,5 @@ func TestAttachUeWithConfiguration(tunnelEnabled bool) {
 	if tunnelEnabled {
 		tunnelMode = config.TunnelVrf
 	}
-	TestMultiUesInQueue(1, tunnelMode, true, false, 500, 0, 0, 0, 0, 0, 1)
+	TestMultiUesInQueue(1, tunnelMode, true, false, 0, 500, 0, 0, 0, 0, 0, 1)
 }

--- a/internal/templates/test-attach-ue-with-configuration.go
+++ b/internal/templates/test-attach-ue-with-configuration.go
@@ -11,5 +11,5 @@ func TestAttachUeWithConfiguration(tunnelEnabled bool) {
 	if tunnelEnabled {
 		tunnelMode = config.TunnelVrf
 	}
-	TestMultiUesInQueue(1, tunnelMode, true, false, 0, 500, 0, 0, 0, 0, 0, 1)
+	TestMultiUesInQueue(1, tunnelMode, true, false, 0, 200, 500, 0, 0, 0, 0, 0, 1)
 }

--- a/internal/templates/test-multi-ues-in-queue.go
+++ b/internal/templates/test-multi-ues-in-queue.go
@@ -16,7 +16,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func TestMultiUesInQueue(numUes int, tunnelMode config.TunnelMode, dedicatedGnb bool, loop bool, loopCount int, timeBetweenRegistration int, timeBeforeDeregistration int, timeBeforeNgapHandover int, timeBeforeXnHandover int, timeBeforeIdle int, timeBeforeReconnecting int, numPduSessions int) {
+func TestMultiUesInQueue(numUes int, tunnelMode config.TunnelMode, dedicatedGnb bool, loop bool, loopCount int, timeBeforeReregistration int, timeBetweenRegistration int, timeBeforeDeregistration int, timeBeforeNgapHandover int, timeBeforeXnHandover int, timeBeforeIdle int, timeBeforeReconnecting int, numPduSessions int) {
 	if tunnelMode != config.TunnelDisabled {
 		if !dedicatedGnb {
 			log.Fatal("You cannot use the --tunnel option, without using the --dedicatedGnb option")
@@ -68,6 +68,7 @@ func TestMultiUesInQueue(numUes int, tunnelMode config.TunnelMode, dedicatedGnb 
 		NumPduSessions:           numPduSessions,		
 		RegistrationLoop:		  loop,		
 		LoopCount:				  loopCount,
+		TimeBeforeReregistration: timeBeforeReregistration,
 	}
 
 	stopSignal := true

--- a/test/pr_test.go
+++ b/test/pr_test.go
@@ -201,7 +201,7 @@ func TestUERegistrationLoop(t *testing.T) {
 		UeId:                     1,
 		Gnbs:                     gnbs,
 		Cfg:                      conf,
-		TimeBeforeDeregistration: 3000,
+		TimeBeforeDeregistration: 2000,
 		TimeBeforeNgapHandover:   0,
 		TimeBeforeXnHandover:     0,
 		NumPduSessions:           1,


### PR DESCRIPTION
Hello, 

I encountered an issue where packet-rusher crashed after a second with a nil pointer dereference when being executed with "multi-ue -n 1 --tr 500 --td 3000 --loop" parameters. I found this is caused by SimulateSingleUE() being executed every tr ms, where a new coroutine for the same UE is created faster than the previously created coroutine deregisters due to td > tr. 

I thought it makes more sense to move the loop inside the UE coroutine, so it is ensured that the same UE is always executed just once at a time. Also, I fixed the tests and had to introduce an additional loopCount parameter, because for TestUERegistrationLoop() the loop needs to be executed for a specific number of times.

Kind regards

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- TO DO before submitting a Pull Request, make sure to put an `x` in all the boxes -->
- [x] I have read the **CONTRIBUTING** document.
- [x] Each of my commits messages include `Signed-off-by: Author Name <authoremail@example.com>` to accept the DCO.
