### PR TITLE
add source interface

### DIFF
--- a/internal/control_test_engine/ue/gtp/service/service.go
+++ b/internal/control_test_engine/ue/gtp/service/service.go
@@ -85,7 +85,8 @@ func SetupGtpInterface(ue *context.UEContext, msg gnbContext.UEMessage) {
 		return
 	}
 
-	cmdAddPdr := []string{nameInf, "1", "--pcd", "1", "--hdr-rm", "0", "--ue-ipv4", ueIp, "--f-teid", fmt.Sprint(gnbPduSession.GetTeidDownlink()), msg.GnbIp, "--far-id", "1"}
+	cmdAddPdr := []string{nameInf, "1", "--pcd", "1", "--hdr-rm", "0", "--ue-ipv4", ueIp, "--f-teid", 
+			fmt.Sprint(gnbPduSession.GetTeidDownlink()), msg.GnbIp, "--far-id", "1", "--source-interface", "1"}
 	log.Debug("[UE][GTP] Setting up GTP Packet Detection Rule for ", strings.Join(cmdAddPdr, " "))
 
 	if err := gtpTunnel.CmdAddPDR(cmdAddPdr); err != nil {


### PR DESCRIPTION
feat: align source interface option with gtp5g

gtp5g from https://github.com/free5gc/gtp5g/commits/master/

gtp5g (commit d4c2d6effe5c35bbe5bee9b7040056649aedf95a) uses source interface to determine whether to match the inner source or destination address.  
To align with this change, "--source-interface 1" is added.  