### PR TITLE
Represent IP addresses as netip.AddrPort

### DIFF
--- a/cmd/packetrusher.go
+++ b/cmd/packetrusher.go
@@ -45,10 +45,10 @@ func main() {
 					log.Info("[TESTER] Starting test function: ", name)
 					log.Info("[TESTER][UE] Number of UEs: ", 1)
 					log.Info("[TESTER][UE] disableTunnel is ", !tunnelEnabled)
-					log.Info("[TESTER][GNB] Control interface IP/Port: ", cfg.GNodeB.ControlIF.Ip, "/", cfg.GNodeB.ControlIF.Port, "~")
-					log.Info("[TESTER][GNB] Data interface IP/Port: ", cfg.GNodeB.DataIF.Ip, "/", cfg.GNodeB.DataIF.Port)
+					log.Info("[TESTER][GNB] Control interface IP/Port: ", cfg.GNodeB.ControlIF.AddrPort, "~")
+					log.Info("[TESTER][GNB] Data interface IP/Port: ", cfg.GNodeB.DataIF.AddrPort)
 					for _, amf := range cfg.AMFs {
-						log.Info("[TESTER][AMF] AMF IP/Port: ", amf.Ip, "/", amf.Port)
+						log.Info("[TESTER][AMF] AMF IP/Port: ", amf.AddrPort)
 					}
 					log.Info("---------------------------------------")
 
@@ -71,10 +71,10 @@ func main() {
 					log.Info("---------------------------------------")
 					log.Info("[TESTER] Starting test function: ", name)
 					log.Info("[TESTER][GNB] Number of GNBs: ", 1)
-					log.Info("[TESTER][GNB] Control interface IP/Port: ", cfg.GNodeB.ControlIF.Ip, "/", cfg.GNodeB.ControlIF.Port, "~")
-					log.Info("[TESTER][GNB] Data interface IP/Port: ", cfg.GNodeB.DataIF.Ip, "/", cfg.GNodeB.DataIF.Port)
+					log.Info("[TESTER][GNB] Control interface IP/Port: ", cfg.GNodeB.ControlIF.AddrPort, "~")
+					log.Info("[TESTER][GNB] Data interface IP/Port: ", cfg.GNodeB.DataIF.AddrPort)
 					for _, amf := range cfg.AMFs {
-						log.Info("[TESTER][AMF] AMF IP/Port: ", amf.Ip, "/", amf.Port)
+						log.Info("[TESTER][AMF] AMF IP/Port: ", amf.AddrPort)
 					}
 					log.Info("---------------------------------------")
 					templates.TestAttachGnbWithConfiguration()
@@ -119,10 +119,10 @@ func main() {
 					log.Info("---------------------------------------")
 					log.Info("[TESTER] Starting test function: ", name)
 					log.Info("[TESTER][UE] Number of UEs: ", numUes)
-					log.Info("[TESTER][GNB] gNodeB control interface IP/Port: ", cfg.GNodeB.ControlIF.Ip, "/", cfg.GNodeB.ControlIF.Port, "~")
-					log.Info("[TESTER][GNB] gNodeB data interface IP/Port: ", cfg.GNodeB.DataIF.Ip, "/", cfg.GNodeB.DataIF.Port)
+					log.Info("[TESTER][GNB] gNodeB control interface IP/Port: ", cfg.GNodeB.ControlIF.AddrPort, "~")
+					log.Info("[TESTER][GNB] gNodeB data interface IP/Port: ", cfg.GNodeB.DataIF.AddrPort)
 					for _, amf := range cfg.AMFs {
-						log.Info("[TESTER][AMF] AMF IP/Port: ", amf.Ip, "/", amf.Port)
+						log.Info("[TESTER][AMF] AMF IP/Port: ", amf.AddrPort)
 					}
 					log.Info("---------------------------------------")
 
@@ -188,10 +188,10 @@ func main() {
 					log.Info("---------------------------------------")
 					log.Warn("[TESTER] Starting test function: ", name)
 					log.Warn("[TESTER][UE] Number of Requests per second: ", numRqs)
-					log.Info("[TESTER][GNB] gNodeB control interface IP/Port: ", cfg.GNodeB.ControlIF.Ip, "/", cfg.GNodeB.ControlIF.Port)
-					log.Info("[TESTER][GNB] gNodeB data interface IP/Port: ", cfg.GNodeB.DataIF.Ip, "/", cfg.GNodeB.DataIF.Port)
+					log.Info("[TESTER][GNB] gNodeB control interface IP/Port: ", cfg.GNodeB.ControlIF.AddrPort)
+					log.Info("[TESTER][GNB] gNodeB data interface IP/Port: ", cfg.GNodeB.DataIF.AddrPort)
 					for _, amf := range cfg.AMFs {
-						log.Info("[TESTER][AMF] AMF IP/Port: ", amf.Ip, "/", amf.Port)
+						log.Info("[TESTER][AMF] AMF IP/Port: ", amf.AddrPort)
 					}
 					log.Info("---------------------------------------")
 					log.Warn("[TESTER][GNB] Total of AMF Responses in the interval:", templates.TestRqsLoop(numRqs, time))
@@ -217,10 +217,10 @@ func main() {
 					log.Info("---------------------------------------")
 					log.Warn("[TESTER] Starting test function: ", name)
 					log.Warn("[TESTER][UE] Interval of test: ", time, " seconds")
-					log.Info("[TESTER][GNB] Control interface IP/Port: ", cfg.GNodeB.ControlIF.Ip, "/", cfg.GNodeB.ControlIF.Port)
-					log.Info("[TESTER][GNB] Data interface IP/Port: ", cfg.GNodeB.DataIF.Ip, "/", cfg.GNodeB.DataIF.Port)
+					log.Info("[TESTER][GNB] Control interface IP/Port: ", cfg.GNodeB.ControlIF.AddrPort)
+					log.Info("[TESTER][GNB] Data interface IP/Port: ", cfg.GNodeB.DataIF.AddrPort)
 					for _, amf := range cfg.AMFs {
-						log.Info("[TESTER][AMF] AMF IP/Port: ", amf.Ip, "/", amf.Port)
+						log.Info("[TESTER][AMF] AMF IP/Port: ", amf.AddrPort)
 					}
 					log.Info("---------------------------------------")
 					templates.TestAvailability(time)

--- a/config/ipv4-port.go
+++ b/config/ipv4-port.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+
+	"github.com/goccy/go-yaml"
+)
+
+// IPv4Port is a tuple of IPv4 address and port number.
+type IPv4Port struct {
+	netip.AddrPort
+}
+
+var _ yaml.InterfaceUnmarshalerContext = &IPv4Port{}
+
+// UnmarshalYAML implements yaml.InterfaceUnmarshalerContext interface.
+func (v *IPv4Port) UnmarshalYAML(ctx context.Context, unmarshal func(interface{}) error) error {
+	var value struct {
+		IP   string `yaml:"ip"`   // IPv4 address or hostname
+		Port uint16 `yaml:"port"` // port number
+	}
+	if e := unmarshal(&value); e != nil {
+		return e
+	}
+
+	ips, e := net.DefaultResolver.LookupNetIP(ctx, "ip4", value.IP)
+	if e != nil || len(ips) == 0 {
+		return fmt.Errorf("cannot resolve %s as IPv4 address: %w", value.IP, e)
+	}
+
+	v.AddrPort = netip.AddrPortFrom(ips[0].Unmap(), value.Port)
+	return nil
+}
+
+// WithNextAddr returns a copy of IPv4Port with the next IPv4 address.
+func (v IPv4Port) WithNextAddr() (copy IPv4Port) {
+	copy.AddrPort = netip.AddrPortFrom(v.Addr().Next(), v.Port())
+	return
+}
+
+// WithPort returns a copy of IPv4Port with the specified port number.
+func (v IPv4Port) WithPort(port uint16) (copy IPv4Port) {
+	copy.AddrPort = netip.AddrPortFrom(v.Addr(), port)
+	return
+}

--- a/internal/control_test_engine/gnb/context/amf.go
+++ b/internal/control_test_engine/gnb/context/amf.go
@@ -6,6 +6,7 @@ package context
 
 import (
 	"fmt"
+	"net/netip"
 
 	"github.com/free5gc/aper"
 	"github.com/ishidawataru/sctp"
@@ -17,8 +18,7 @@ const Active = 0x01
 const Overload = 0x02
 
 type GNBAmf struct {
-	amfIp               string         // AMF ip
-	amfPort             int            // AMF port
+	amfIpPort           netip.AddrPort // AMF ip and port
 	amfId               int64          // AMF id
 	tnla                TNLAssociation // AMF sctp associations
 	relativeAmfCapacity int64          // AMF capacity
@@ -214,20 +214,12 @@ func (amf *GNBAmf) GetTNLAStreams() uint16 {
 	return amf.tnla.streams
 }
 
-func (amf *GNBAmf) GetAmfIp() string {
-	return amf.amfIp
+func (amf *GNBAmf) GetAmfIpPort() netip.AddrPort {
+	return amf.amfIpPort
 }
 
-func (amf *GNBAmf) SetAmfIp(ip string) {
-	amf.amfIp = ip
-}
-
-func (amf *GNBAmf) GetAmfPort() int {
-	return amf.amfPort
-}
-
-func (amf *GNBAmf) setAmfPort(port int) {
-	amf.amfPort = port
+func (amf *GNBAmf) SetAmfIpPort(ap netip.AddrPort) {
+	amf.amfIpPort = ap
 }
 
 func (amf *GNBAmf) GetAmfId() int64 {

--- a/internal/control_test_engine/gnb/gnb.go
+++ b/internal/control_test_engine/gnb/gnb.go
@@ -33,15 +33,14 @@ func InitGnb(conf config.Config, wg *sync.WaitGroup) *context.GNBContext {
 		conf.GNodeB.PlmnList.Tac,
 		conf.GNodeB.SliceSupportList.Sst,
 		conf.GNodeB.SliceSupportList.Sd,
-		conf.GNodeB.ControlIF.Ip,
-		conf.GNodeB.DataIF.Ip,
-		conf.GNodeB.ControlIF.Port,
-		conf.GNodeB.DataIF.Port)
+		conf.GNodeB.ControlIF.AddrPort,
+		conf.GNodeB.DataIF.AddrPort,
+	)
 
 	// start communication with AMF (server SCTP).
 	for _, amfConfig := range conf.AMFs {
 		// new AMF context.
-		amf := gnb.NewGnBAmf(amfConfig.Ip, amfConfig.Port)
+		amf := gnb.NewGnBAmf(amfConfig.AddrPort)
 
 		// start communication with AMF(SCTP).
 		if err := ngap.InitConn(amf, gnb); err != nil {
@@ -85,15 +84,13 @@ func InitGnbForLoadSeconds(conf config.Config, wg *sync.WaitGroup,
 		conf.GNodeB.PlmnList.Tac,
 		conf.GNodeB.SliceSupportList.Sst,
 		conf.GNodeB.SliceSupportList.Sd,
-		conf.GNodeB.ControlIF.Ip,
-		conf.GNodeB.DataIF.Ip,
-		conf.GNodeB.ControlIF.Port,
-		conf.GNodeB.DataIF.Port)
+		conf.GNodeB.ControlIF.AddrPort,
+		conf.GNodeB.DataIF.AddrPort)
 
 	// start communication with AMF (server SCTP).
 	for _, amf := range conf.AMFs {
 		// new AMF context.
-		amf := gnb.NewGnBAmf(amf.Ip, amf.Port)
+		amf := gnb.NewGnBAmf(amf.AddrPort)
 
 		// start communication with AMF(SCTP).
 		ngap.InitConn(amf, gnb)
@@ -129,15 +126,13 @@ func InitGnbForAvaibility(conf config.Config,
 		conf.GNodeB.PlmnList.Tac,
 		conf.GNodeB.SliceSupportList.Sst,
 		conf.GNodeB.SliceSupportList.Sd,
-		conf.GNodeB.ControlIF.Ip,
-		conf.GNodeB.DataIF.Ip,
-		conf.GNodeB.ControlIF.Port,
-		conf.GNodeB.DataIF.Port)
+		conf.GNodeB.ControlIF.AddrPort,
+		conf.GNodeB.DataIF.AddrPort)
 
 	// start communication with AMF (server SCTP).
 	for _, amf := range conf.AMFs {
 		// new AMF context.
-		amf := gnb.NewGnBAmf(amf.Ip, amf.Port)
+		amf := gnb.NewGnBAmf(amf.AddrPort)
 
 		// start communication with AMF(SCTP).
 		if err := ngap.InitConn(amf, gnb); err != nil {

--- a/internal/control_test_engine/gnb/ngap/service.go
+++ b/internal/control_test_engine/gnb/ngap/service.go
@@ -5,8 +5,8 @@
 package ngap
 
 import (
-	"fmt"
 	"my5G-RANTester/internal/control_test_engine/gnb/context"
+	"net/netip"
 
 	"github.com/ishidawataru/sctp"
 	log "github.com/sirupsen/logrus"
@@ -17,8 +17,9 @@ var ConnCount int
 func InitConn(amf *context.GNBAmf, gnb *context.GNBContext) error {
 
 	// check AMF IP and AMF port.
-	remote := fmt.Sprintf("%s:%d", amf.GetAmfIp(), amf.GetAmfPort())
-	local := fmt.Sprintf("%s:%d", gnb.GetGnbIp(), gnb.GetGnbPort()+ConnCount)
+	remote := amf.GetAmfIpPort().String()
+	gnbAddrPort := gnb.GetGnbIpPort()
+	local := netip.AddrPortFrom(gnbAddrPort.Addr(), gnbAddrPort.Port()+uint16(ConnCount)).String()
 	ConnCount++
 
 	rem, err := sctp.ResolveSCTPAddr("sctp", remote)

--- a/internal/templates/test-amf-availability.go
+++ b/internal/templates/test-amf-availability.go
@@ -19,7 +19,7 @@ func TestAvailability(interval int) {
 
 	conf := config.GetConfig()
 
-	ranPort := 1000
+	ranPort := uint16(1000)
 	for y := 1; y <= interval; y++ {
 
 		monitor.InitAvaibility()
@@ -28,7 +28,7 @@ func TestAvailability(interval int) {
 
 			conf.GNodeB.PlmnList.GnbId = gnbIdGenerator(i)
 
-			conf.GNodeB.ControlIF.Port = ranPort
+			conf.GNodeB.ControlIF = conf.GNodeB.ControlIF.WithPort(ranPort)
 
 			go gnb.InitGnbForAvaibility(conf, &monitor)
 
@@ -45,6 +45,4 @@ func TestAvailability(interval int) {
 
 		}
 	}
-
-	return
 }

--- a/internal/templates/test-amf-requests-per-second.go
+++ b/internal/templates/test-amf-requests-per-second.go
@@ -29,7 +29,7 @@ func TestRqsLoop(numRqs int, interval int) int64 {
 
 	cfg := config.GetConfig()
 
-	ranPort := 1000
+	ranPort := uint16(1000)
 	for y := 1; y <= interval; y++ {
 
 		monitor.InitRqsLocal()
@@ -38,7 +38,7 @@ func TestRqsLoop(numRqs int, interval int) int64 {
 
 			cfg.GNodeB.PlmnList.GnbId = gnbIdGenerator(i)
 
-			cfg.GNodeB.ControlIF.Port = ranPort
+			cfg.GNodeB.ControlIF = cfg.GNodeB.ControlIF.WithPort(ranPort)
 
 			go gnb.InitGnbForLoadSeconds(cfg, &wg, &monitor)
 

--- a/internal/utils/pcap.go
+++ b/internal/utils/pcap.go
@@ -6,7 +6,6 @@ package pcap
 
 import (
 	"my5G-RANTester/config"
-	"net"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -48,7 +47,7 @@ func CaptureTraffic(path cli.Path) {
 
 func findN2Link() netlink.Link {
 	config := config.GetConfig()
-	ip := net.ParseIP(config.GNodeB.ControlIF.Ip)
+	ip := config.GNodeB.ControlIF.Addr().AsSlice()
 
 	links, err := netlink.LinkList()
 	if err != nil {

--- a/test/aio5gc/build.go
+++ b/test/aio5gc/build.go
@@ -95,7 +95,7 @@ func (f *FiveGCBuilder) Build() (*context.Aio5gc, error) {
 		fgc.SetNgapHooks(f.ngapHook)
 	}
 	for _, amf := range f.config.AMFs {
-		go service.RunServer(amf.Ip, amf.Port, &fgc)
+		go service.RunServer(amf.AddrPort, &fgc)
 	}
 	return &fgc, nil
 }

--- a/test/aio5gc/lib/tools/tools.go
+++ b/test/aio5gc/lib/tools/tools.go
@@ -6,13 +6,14 @@ package tools
 
 import (
 	"my5G-RANTester/config"
+	"net/netip"
 )
 
-func GenerateDefaultConf(controlIF config.ControlIF, dataIF config.DataIF, amfs []*config.AMF) config.Config {
+func GenerateDefaultConf(controlIF netip.AddrPort, dataIF netip.AddrPort, amfs []*config.AMF) config.Config {
 	return config.Config{
 		GNodeB: config.GNodeB{
-			ControlIF: controlIF,
-			DataIF:    dataIF,
+			ControlIF: config.IPv4Port{AddrPort: controlIF},
+			DataIF:    config.IPv4Port{AddrPort: dataIF},
 			PlmnList: config.PlmnList{
 				Mcc:   "999",
 				Mnc:   "70",

--- a/test/aio5gc/service/service.go
+++ b/test/aio5gc/service/service.go
@@ -5,9 +5,9 @@
 package service
 
 import (
-	"fmt"
 	"my5G-RANTester/test/aio5gc/context"
 	"my5G-RANTester/test/aio5gc/msg/ngap"
+	"net/netip"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -17,8 +17,8 @@ import (
 
 var bufsize = 65535
 
-func RunServer(ServerIp string, ServerPort int, fgc *context.Aio5gc) {
-	addr, err := sctp.ResolveSCTPAddr("sctp", fmt.Sprintf("%s:%d", ServerIp, ServerPort))
+func RunServer(ServerIpPort netip.AddrPort, fgc *context.Aio5gc) {
+	addr, err := sctp.ResolveSCTPAddr("sctp", ServerIpPort.String())
 	if err != nil {
 		log.Fatalf("[5GC] Failed to resolve MockedAMF SCTP address %v", err)
 	}

--- a/test/pr_test.go
+++ b/test/pr_test.go
@@ -12,6 +12,7 @@ import (
 	"my5G-RANTester/test/aio5gc"
 	"my5G-RANTester/test/aio5gc/context"
 	amfTools "my5G-RANTester/test/aio5gc/lib/tools"
+	"net/netip"
 	"os"
 	"sync"
 	"testing"
@@ -25,19 +26,10 @@ import (
 
 func TestRegistrationToCtxReleaseWithPDUSession(t *testing.T) {
 
-	controlIFConfig := config.ControlIF{
-		Ip:   "127.0.0.1",
-		Port: 9489,
-	}
-	dataIFConfig := config.DataIF{
-		Ip:   "127.0.0.1",
-		Port: 2154,
-	}
+	controlIFConfig := netip.MustParseAddrPort("127.0.0.1:9489")
+	dataIFConfig := netip.MustParseAddrPort("127.0.0.1:2154")
 	amfListConfig := []*config.AMF{
-		{
-			Ip:   "127.0.0.1",
-			Port: 38414,
-		},
+		{IPv4Port: config.IPv4Port{AddrPort: netip.MustParseAddrPort("127.0.0.1:38414")}},
 	}
 
 	conf := amfTools.GenerateDefaultConf(controlIFConfig, dataIFConfig, amfListConfig)
@@ -141,19 +133,10 @@ func TestRegistrationToCtxReleaseWithPDUSession(t *testing.T) {
 }
 
 func TestUERegistrationLoop(t *testing.T) {
-	controlIFConfig := config.ControlIF{
-		Ip:   "127.0.0.1",
-		Port: 9490,
-	}
-	dataIFConfig := config.DataIF{
-		Ip:   "127.0.0.1",
-		Port: 2155,
-	}
+	controlIFConfig := netip.MustParseAddrPort("127.0.0.1:9490")
+	dataIFConfig := netip.MustParseAddrPort("127.0.0.1:2155")
 	amfListConfig := []*config.AMF{
-		{
-			Ip:   "127.0.0.1",
-			Port: 38415,
-		},
+		{IPv4Port: config.IPv4Port{AddrPort: netip.MustParseAddrPort("127.0.0.1:38415")}},
 	}
 
 	type UECheck struct {


### PR DESCRIPTION
**netip.Addr** and **netip.AddrPort**, introduced in Go 1.18, are more strict than **net.IP** or strings.

The breaking changes include:

* **config.Config** is an exported non-internal type. Its fields are changed.
* There are some minor changes in the log messages related to DNS resolution.

There's no functionality change other than these.
The YAML configuration format also remains the same.

To limit the complexity of this patch, **GNBContext.GetN3GnbIp** and **UEMessage.GnbIp** are still strings, but they will be changed to **netip.Addr** in the future.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- TO DO before submitting a Pull Request, make sure to put an `x` in all the boxes -->
- [X] I have read the **CONTRIBUTING** document.
- [X] Each of my commits messages include `Signed-off-by: Author Name <authoremail@example.com>` to accept the DCO.
