### PR TITLE
Add logic to prevent gNB crash under PDU session create failure

### DIFF
--- a/internal/control_test_engine/gnb/ngap/handler.go
+++ b/internal/control_test_engine/gnb/ngap/handler.go
@@ -381,6 +381,16 @@ func HandlerPduSessionResourceSetupRequest(gnb *context.GNBContext, message *nga
 			log.Error("[GNB][NGAP] Error in Pdu Session Resource Setup Request.")
 			log.Error("[GNB][NGAP] ", err)
 
+			// If PDU session already exists, retrieve it instead of failing
+			existingSession, getErr := ue.GetPduSession(pduSessionId)
+			if getErr == nil && existingSession != nil {
+				log.Warn("[GNB][NGAP] PDU Session ", pduSessionId, " already exists, using existing session")
+				pduSession = existingSession
+			} else {
+				// Cannot create or retrieve session, skip this item
+				log.Error("[GNB][NGAP] Cannot create or retrieve PDU Session ", pduSessionId, ", skipping")
+				continue
+			}
 		}
 		configuredPduSessions = append(configuredPduSessions, pduSession)
 


### PR DESCRIPTION
In the HandlerPduSessionResourceSetupRequest function, the code attempts to access the pduSession object even when CreatePduSession fails and returns nil, causing PacketRusher to crash.
According to the CreatePduSession implementation, the function can fail in three cases:

The PDU session ID is invalid
A PDU session with the given ID already exists
Network slice configuration mismatch (SST, SD)

For the second case, we can simply return the existing PDU session. For the first and third cases, the gNB should not proceed with a nil object. Instead, it should skip to the next iteration and continue processing remaining items in the PDUSessionResourceSetupList.
This error occurred when I generated high-volume control plane traffic to the open5gs core. Since current repo does not include RPS (Requests Per Second) load testing script and I used my own one, I cannot include it with this PR. I plan to submit it in a separate PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- TO DO before submitting a Pull Request, make sure to put an `x` in all the boxes -->
- [x] I have read the **CONTRIBUTING** document.
- [x] Each of my commits messages include `Signed-off-by: Author Name <authoremail@example.com>` to accept the DCO.
