### PR TITLE
Make NAS-PDU in PDU Session Resource Setup Request List IE be optional

### DIFF
--- a/internal/control_test_engine/gnb/ngap/handler.go
+++ b/internal/control_test_engine/gnb/ngap/handler.go
@@ -317,7 +317,7 @@ func HandlerPduSessionResourceSetupRequest(gnb *context.GNBContext, message *nga
 		if item.PDUSessionNASPDU != nil {
 			messageNas = item.PDUSessionNASPDU.Value
 		} else {
-			log.Info("[GNB][NGAP] NAS PDU not present (normal for Service Request scenario)")
+			log.Info("[GNB][NGAP] NAS PDU is missing")
 		}
 
 		// check pdu session id and nssai information for create a PDU Session.


### PR DESCRIPTION
Based on the section 9.2.1.1 of TS 38.413, the NAS-PDU is marked as optional for PDU Session Resource Setup Request - PDU Session Resource Setup Request List IEs.
This PR modifies that point.

<img width="764" height="609" alt="image" src="https://github.com/user-attachments/assets/0d85bf3a-799d-43f4-8660-7fcd893add20" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- TO DO before submitting a Pull Request, make sure to put an `x` in all the boxes -->
- [x] I have read the **CONTRIBUTING** document.
- [x] Each of my commits messages include `Signed-off-by: Author Name <authoremail@example.com>` to accept the DCO.
