### PR TITLE
Add fallback mechanism for gNB N3 IP setting

### DIFF
--- a/internal/control_test_engine/gnb/gnb.go
+++ b/internal/control_test_engine/gnb/gnb.go
@@ -34,12 +34,14 @@ func InitGnb(conf config.Config, wg *sync.WaitGroup) *context.GNBContext {
 	for _, amfConfig := range conf.AMFs {
 		connected := false
 		currentN2IP := conf.GNodeB.ControlIF
+		currentN3IP := conf.GNodeB.DataIF
 
 		for retry := 0; retry < maxRetries && !connected; retry++ {
 			if retry > 0 {
-				// Increment N2 IP address for retry
+				// Increment both N2 and N3 IP addressese for retry
 				currentN2IP = currentN2IP.WithNextAddr()
-				log.Info("[GNB] Retrying with N2 IP: ", currentN2IP.String())
+				currentN3IP = currentN3IP.WithNextAddr()
+				log.Info("[GNB] Retrying with N2 IP: ", currentN2IP.String(), ", N3 IP: ", currentN3IP.String())
 			} else {
 				log.Info("[GNB] Attempting connection with N2 IP: ", currentN2IP.String())
 			}
@@ -53,7 +55,7 @@ func InitGnb(conf config.Config, wg *sync.WaitGroup) *context.GNBContext {
 				conf.GNodeB.SliceSupportList.Sst,
 				conf.GNodeB.SliceSupportList.Sd,
 				currentN2IP.AddrPort,
-				conf.GNodeB.DataIF.AddrPort,
+				currentN3IP.AddrPort,
 			)
 
 			// new AMF context.


### PR DESCRIPTION
Hi, and thank you for your work.

Similar to PR #190, it would be great to have the gNB N3 IP setting use the same fallback mechanism as the one implemented for the N2 IP address setting.
This PR adds that feature.

Thanks, as always.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- TO DO before submitting a Pull Request, make sure to put an `x` in all the boxes -->
- [x] I have read the **CONTRIBUTING** document.
- [x] Each of my commits messages include `Signed-off-by: Author Name <authoremail@example.com>` to accept the DCO.
